### PR TITLE
Update slickmap_css_sitemap_setclass.js

### DIFF
--- a/js/slickmap_css_sitemap_setclass.js
+++ b/js/slickmap_css_sitemap_setclass.js
@@ -1,6 +1,13 @@
 jQuery(document).ready(function ($) {
 
-	$(".slickmap>ul").attr("id", "primaryNav");
+	if ($(".slickmap>ul").length > 1)
+	{
+	    $(".slickmap>ul:nth-child(2)").attr('id', 'utilityNav');
+	    $(".slickmap>ul:nth-child(3)").attr('id', 'primaryNav');
+	} else { 
+	    $(".slickmap>ul").attr("id", "primaryNav");
+	}
+	
 	$("#primaryNav>li:first-child").attr("id", "home");
 	var breakpoint = 768;
 	if (slickmapSettings) {


### PR DESCRIPTION
support utilityNav by counting number of UL's, turning the first in to the utilityNav, and the second into the primaryNav. Needs further consideration when more than two ULs, or when two full sitemaps are needed (should use two shortcodes)
